### PR TITLE
Update to support Azure SignalR Service endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/.vs/slnx.sqlite-journal
+/.vs/slnx.sqlite

--- a/signalrcore/helpers.py
+++ b/signalrcore/helpers.py
@@ -1,0 +1,43 @@
+from urllib import parse
+
+class helpers:
+    @staticmethod
+    def websocket_to_http(url):
+        urlParts = parse.urlsplit(url)
+
+        if "http" not in urlParts.scheme:
+            if urlParts.scheme == "wss" : urlParts = urlParts._replace(scheme="https")  
+            if urlParts.scheme == "ws" : urlParts = urlParts._replace(scheme="http")
+
+        return parse.urlunsplit(urlParts)
+
+    @staticmethod
+    def http_to_websocket(url):
+        urlParts = parse.urlsplit(url)
+
+        if "ws" not in urlParts.scheme:
+            if urlParts.scheme == "https" : urlParts = urlParts._replace(scheme="wss")  
+            if urlParts.scheme == "http" : urlParts = urlParts._replace(scheme="ws")
+
+        return parse.urlunsplit(urlParts)
+
+    @staticmethod
+    def get_negotiate_url(url):   
+        urlParts = parse.urlsplit(helpers.websocket_to_http(url))
+
+        negotiate_suffix = "negotiate" if urlParts.path.endswith('/') else "/negotiate"
+
+        urlParts = urlParts._replace(path=urlParts.path + negotiate_suffix)
+
+        return parse.urlunsplit(urlParts)
+
+    @staticmethod
+    def encode_connection_id(url, id):
+        url_parts = parse.urlsplit(url)
+
+        query_string_parts = parse.parse_qs(url_parts.query)
+        query_string_parts["id"] = id
+
+        url_parts = url_parts._replace(query=parse.urlencode(query_string_parts, doseq=True))
+
+        return helpers.http_to_websocket(parse.urlunsplit(url_parts))

--- a/signalrcore/hub/auth_hub_connection.py
+++ b/signalrcore/hub/auth_hub_connection.py
@@ -1,15 +1,18 @@
 import requests
 
-from .base_hub_connection import BaseHubConnection
+from urllib import parse
 
+from .base_hub_connection import BaseHubConnection
+from ..helpers import helpers
 
 class AuthHubConnection(BaseHubConnection):
     def __init__(self, url, protocol, token, negotiate_headers):
         self.token = token
         self.negotiate_headers = negotiate_headers
-        negotiate_url = "https" + url[3:] if url.startswith("wss") else "http" + url[2:]
-        negotiate_url += "/negotiate"
-        response = requests.post(negotiate_url, headers=self.negotiate_headers)
+
+        response = requests.post(helpers.get_negotiate_url(url), headers=self.negotiate_headers)
         data = response.json()
-        url = url + "?id={0}&access_token={1}".format(data["connectionId"], self.token)
-        super(AuthHubConnection, self).__init__(url, protocol)
+
+        url = helpers.encode_connection_id(url, data["connectionId"])
+        
+        super(AuthHubConnection, self).__init__(url, protocol, headers=self.negotiate_headers)


### PR DESCRIPTION
Added Helper.py to:
- assist in transforming back and forth between http/s and ws/s. This is useful during negotiate process
- easily get a valid negotiate url irrespective of what is already in the path, query string or paramaters.

Updated hub_connection_builder.py:
Tries to 'negotiate' even for non-auth connections, this allows for unauthenticated Azure SignalR Service usage. If negotiation with Azure SignalR Service is successful, uses AuthConnectionHub instead of BaseConnectionHub

Updated auth_hub_connection.py: 
- Uses helper class to append 'negotiate' to end of path instead of url. Now supports Azure SignalR Service which has query parameters in its negotiate endpoint.