### PR TITLE
Missing colon in base_hub_connection.py

### DIFF
--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -72,7 +72,7 @@ class BaseHubConnection(websocket.WebSocketApp):
             reconnection_type,
             keep_alive_interval=15,
             reconnect_interval=5,
-            max_attemps=None)
+            max_attemps=None):
 
         self.connection_checker.keep_alive_interval = keep_alive_interval
 

--- a/signalrcore/hub/reconnection.py
+++ b/signalrcore/hub/reconnection.py
@@ -1,4 +1,6 @@
 from enum import Enum
+import threading
+import time
 
 
 class ConnectionStateChecker(threading.Thread):


### PR DESCRIPTION
There is missing colon in base_hub_connection.py line 75.
Result of pylint:
```
************* Module signalrcore.hub.base_hub_connection
signalrcore/hub/base_hub_connection.py:75:0: E0001: invalid syntax (<unknown>, line 75) (syntax-error)
```

This PR contains correction of this small type.