### PR TITLE
Fixed state change of Hub connection when calling hub_connection.stop() method.

### DIFF
--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -120,7 +120,7 @@ class BaseHubConnection(object):
         if self.state == ConnectionState.connected:
             self._ws.close()
             self.connection_checker.stop()
-            self.state == ConnectionState.disconnected
+            self.state = ConnectionState.disconnected
 
     def register_handler(self, event, callback):
         self.logger.debug("Handler registered started {0}".format(event))


### PR DESCRIPTION
There was an error in code since state "disconnected" wasn't properly assigned to the state of the hub connection when calling hub_connection.stop() method.

The solution was quite trivial: change double equal with single equal.