### PR TITLE
Don't reset keepalive timer on received message

### DIFF
--- a/signalrcore/transport/websockets/websocket_transport.py
+++ b/signalrcore/transport/websockets/websocket_transport.py
@@ -174,7 +174,6 @@ class WebsocketTransport(BaseTransport):
 
     def on_message(self, raw_message):
         self.logger.debug("Message received{0}".format(raw_message))
-        self.connection_checker.last_message = time.time()
         if not self.handshake_received:
             messages = self.evaluate_handshake(raw_message)
             if self._on_open is not None and callable(self._on_open):


### PR DESCRIPTION
Resetting timer on received message leads to server closing connection due to inactivity. [Protocol specs](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md#ping-aka-keep-alive
) mention only sent messages as a reason to skip ping:
>A Ping is only sent if the interval has elapsed without a message being sent.

