### PR TITLE
hcshmk/invocation_id - Read invocation_id from method parameters, letting user override it if desired.

### DIFF
--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -87,7 +87,7 @@ class BaseHubConnection(object):
         self.logger.debug("Handler registered started {0}".format(event))
         self.handlers.append((event, callback_function))
 
-    def send(self, method, arguments, on_invocation=None):
+    def send(self, method, arguments, on_invocation=None, invocation_id=str(uuid.uuid4())):
         """Sends a message
 
         Args:
@@ -109,7 +109,7 @@ class BaseHubConnection(object):
 
         if type(arguments) is list:
             message = InvocationMessage(
-                str(uuid.uuid4()),
+                invocation_id,
                 method,
                 arguments,
                 headers=self.headers)

--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -95,6 +95,9 @@ class BaseHubConnection(object):
             arguments (list|Subject): Method parameters
             on_invocation (function, optional): On invocation send callback
                 will be raised on send server function ends. Defaults to None.
+            invocation_id (string, optional): Override invocation ID. Exceptions
+                thrown by the hub will use this ID, making it easier to handle
+                with the on_error call.
 
         Raises:
             HubConnectionError: If hub is not ready to send


### PR DESCRIPTION
This merge request lets the user supply their own `invocation_id` to the `BaseHubConnection.send` method. The purpose is to allow the user to easily perform error handling on individual requests/calls/invocations by registering an `on_error` event handler that can take advantage of this, as demonstrated below:
```python
# Dict pairing uuid with a function
error_handlers: Dict[UUID, Callable[[str], None]] = dict()

# Handle server-sent exceptions by looking up uuid for that particular call/invocation
def on_error(self, completion_message: CompletionMessage):
    uuid = UUID(completion_message.invocation_id)
    error = completion_message.error
    handler = error_handlers[uuid]
    del error_handlers[uuid]
    handler(error)
connection.on_error(on_error)

# Call hub function with simple error handling
single_use_uuid = uuid.uuid4()
error_handlers[uuid] = lambda error_msg: print(f'This specific call to DoStuff failed with message: {error_msg}')
connection.send(method = 'DoStuff',
                arguments = [],
                on_invocation = lambda response: on_success(response.result),
                invocation_id=str(single_use_uuid))
```
Demo code is kept brief and simple, just for proof of concept. With a few extra lines and a wrapper function, you can get the send function to raise an exception in python whenever invoke fails serverside.