### PR TITLE
fixed: Tokens cover each other when multi-threaded  #72

### DIFF
--- a/signalrcore/hub/auth_hub_connection.py
+++ b/signalrcore/hub/auth_hub_connection.py
@@ -3,10 +3,13 @@ from ..helpers import Helpers
 
 
 class AuthHubConnection(BaseHubConnection):
-    def __init__(self, auth_function, headers={}, **kwargs):
-        self.headers = headers
+    def __init__(self, auth_function, headers=None, **kwargs):
+        if headers is None:
+            self.headers = dict()
+        else:
+            self.headers = headers
         self.auth_function = auth_function
-        super(AuthHubConnection, self).__init__(**kwargs)
+        super(AuthHubConnection, self).__init__(headers=headers, **kwargs)
 
     def start(self):
         try:

--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -24,9 +24,12 @@ class BaseHubConnection(object):
             self,
             url,
             protocol,
-            headers={},
-            **kwargs):        
-        self.headers = headers
+            headers=None,
+            **kwargs):
+        if headers is None:
+            self.headers = dict()
+        else:
+            self.headers = headers
         self.logger = Helpers.get_logger()
         self.handlers = []
         self.stream_handlers = []
@@ -35,7 +38,7 @@ class BaseHubConnection(object):
         self.transport = WebsocketTransport(
             url=url,
             protocol=protocol,
-            headers=headers,
+            headers=self.headers,
             on_message=self.on_message,
             **kwargs)
 

--- a/signalrcore/hub_connection_builder.py
+++ b/signalrcore/hub_connection_builder.py
@@ -27,7 +27,7 @@ class HubConnectionBuilder(object):
             "access_token_factory": None
         }
         self.token = None
-        self.headers = None
+        self.headers = dict()
         self.negotiate_headers = None
         self.has_auth_configured = None
         self.protocol = None
@@ -160,11 +160,10 @@ class HubConnectionBuilder(object):
         """
         if self.protocol is None:
             self.protocol = JsonHubProtocol()
-        self.headers = {}
 
         if "headers" in self.options.keys()\
                 and type(self.options["headers"]) is dict:
-            self.headers = self.options["headers"]
+            self.headers.update(self.options["headers"])
 
         if self.has_auth_configured:
             auth_function = self.options["access_token_factory"]

--- a/signalrcore/transport/websockets/websocket_transport.py
+++ b/signalrcore/transport/websockets/websocket_transport.py
@@ -17,7 +17,7 @@ from ...helpers import Helpers
 class WebsocketTransport(BaseTransport):
     def __init__(self,
             url="",
-            headers={},
+            headers=None,
             keep_alive_interval=15,
             reconnection_handler=None,
             verify_ssl=False,
@@ -30,7 +30,10 @@ class WebsocketTransport(BaseTransport):
         self._thread = None
         self.skip_negotiation = skip_negotiation
         self.url = url
-        self.headers = headers
+        if headers is None:
+            self.headers = dict()
+        else:
+            self.headers = headers
         self.handshake_received = False
         self.token = None  # auth
         self.state = ConnectionState.disconnected


### PR DESCRIPTION
1. Modify the header variable initialization method to prevent the TOKEN from being overwritten due to pointing to the same memory address in multiple threads ；
2. Fixed header variable re-initialization to ensure only one initialization；

#72