### PR TITLE
Demote warning to debug (reduce logspam)

### DIFF
--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -174,9 +174,7 @@ class BaseHubConnection(object):
                         lambda h: h[0] == message.target,
                         self.handlers))
                 if len(fired_handlers) == 0:
-                    self.logger.warning(
-                        "event '{0}' hasn't fire any handler".format(
-                            message.target))
+                    self.logger.debug("event '{0}' hasn't fire any handler".format(message.target))
                 for _, handler in fired_handlers:
                     handler(message.arguments)
 

--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -174,7 +174,7 @@ class BaseHubConnection(object):
                         lambda h: h[0] == message.target,
                         self.handlers))
                 if len(fired_handlers) == 0:
-                    self.logger.debug("event '{0}' hasn't fired any handler".format(message.target))
+                    self.logger.debug(f"event '{message.target}' hasn't fired any handler")
                 for _, handler in fired_handlers:
                     handler(message.arguments)
 

--- a/signalrcore/hub/base_hub_connection.py
+++ b/signalrcore/hub/base_hub_connection.py
@@ -174,7 +174,7 @@ class BaseHubConnection(object):
                         lambda h: h[0] == message.target,
                         self.handlers))
                 if len(fired_handlers) == 0:
-                    self.logger.debug("event '{0}' hasn't fire any handler".format(message.target))
+                    self.logger.debug("event '{0}' hasn't fired any handler".format(message.target))
                 for _, handler in fired_handlers:
                     handler(message.arguments)
 


### PR DESCRIPTION
The message `hasn't fire any handler` is _very_ annoying and does not seem to serve any purpose aside from logspam. In order to prevent this message from appearing in the logs several times a second, the user would have to subscribe to every single event on the hub with an empty lambda. I'd much prefer this _non-warning_ be demoted from loglevel warning to loglevel debug, as it _may_ help a user debug why their application is not responding to serverside events, but has no value in a prod setting.

```
2022-03-30 07:50:50,984 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:50:50,984 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:50:50,984 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:50:50,984 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:50:50,984 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 07:50:50,984] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 07:57:46,736 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 07:57:46,736] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:11:19,684 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 08:11:19,684] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:15:14,440 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 08:15:14,440] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:16:01,850 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 08:16:01,850] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
2022-03-30 08:17:22,659 - SignalRCoreClient - WARNING - event 'OnSubmitDataEntry' hasn't fire any handler
[2022-03-30 08:17:22,659] WARNING in base_hub_connection: event 'OnSubmitDataEntry' hasn't fire any handler
```