### PR TITLE
WIP: Update python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 msgpack==1.0.3
 requests>=2.27.1
-websocket-client==1.0.0
+websocket-client==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 msgpack==1.0.3
-requests>=2.22.0
+requests>=2.27.1
 websocket-client==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-msgpack==1.0.2
+msgpack==1.0.3
 requests>=2.22.0
 websocket-client==1.0.0


### PR DESCRIPTION
It's been a while since requirements.txt has been updated, and a lot has happened in the meantime. The changelog for the three dependencies of this project has some very interesting bug fixes and performance improvements.

I've not noticed any API breakage so far, but I also haven't really tested it much.

<details>
  <summary>websocket-client changelog from 1.0.0 to 1.3.2</summary>

- 1.3.2
  - Add support for pre-initialized stream socket in new WebSocketApp (#804)
  - Remove rel.saferead() in examples (f0bf03d)
  - Increase scope of linting checks (dca4022)
  - Start adding type hints (a8a4099)

- 1.3.1
  - Fix 10 year old bug and improve dispatcher handling for run_forever (#795)
  - Fix run_forever to never return None, only return True or False, and add two tests (#788)
  - Remove Python 3.6 support, EOL in Dec 2021

- 1.3.0
  - BREAKING: Set Origin header to use https:// scheme when wss:// WebSocket URL is passed (#787)
  - Replace deprecated/broken WebSocket URLs with working ones (6ad5197)
  - Add documentation referencing rel for automatic reconnection with run_forever()
  - Add missing opcodes 1012, 1013 (#771)
  - Add errno.ENETUNREACH to improve error handling (da1b050)
  - Minor documentation improvements and typo fixes

- 1.2.3
  - Fix broken run_forever() functionality (#769)

- 1.2.2
  - Migrate wsdump script in setup.py from scripts to newer entry_points (#763)
  - Add support for ssl.SSLContext for arbitrary SSL parameters (#762)
  - Remove keep_running variable (#752)
  - Remove HAVE_CONTEXT_CHECK_HOSTNAME variable (dac1692)
  - Replace deprecated ssl.PROTOCOL_TLS with ssl.PROTOCOL_TLS_CLIENT (#760)
  - Simplify code and improve Python 3 support (#751, #750, #746)
  - Fill default license template fields (#748)
  - Update CI tests
  - Improve documentation (#732, #733, #734, #737, #766, #768)

- 1.2.1
  - Fix python-socks dependency issue mentioned in #728
  - Replace echo.websocket.org with a local websockets echo server for unit tests (4951de2)

- 1.2.0
  - Fix #697, #665: Transition from LGPL 2.1 license to Apache 2.0 license
  - Revert #417 and reimplement SOCKS proxy support with python-socks instead of PySocks (fbcbd43)

- 1.1.1
  - Fix #377: increase exception verbosity in _app.py callback exception
  - Fix #717: race condition during connection close
  - Fix #722: improve handling where credentials include symbols like @
  - Fix #711: improve handling if ssl is None

- 1.1.0
  - Set enable_multithread to True by default (beb135a)
  - Performance improvement in _mask() function (287970e, #433)
  - Performance improvement in recv_strict() function (60e4711, #255)
  - Performance improvement by removing numpy-related code (a462d45)
  - Support uppercase no_proxy, http_proxy, https_proxy env vars (150df4f, #700)
  - Add sslopt 'server_hostname' support (#698)
  - Replace deprecated ssl.PROTOCOL_SSLv23 with ssl.PROTOCOL_TLS (494564f)
  - Update documentation, README (7c9d604, #704)

- 1.0.1
  - Fix exception handling bug #694
</details>
<details>
  <summary>requests changelog from 1.22.0 to 1.27.1</summary>

### 2.27.1 (2022-01-05)
#### Bugfixes:
- Fixed parsing issue that resulted in the auth component being dropped from proxy URLs. (#6028)

### 2.27.0 (2022-01-03)
#### Improvements:
- Officially added support for Python 3.10. (#5928)
- Added a requests.exceptions.JSONDecodeError to unify JSON exceptions between Python 2 and 3. This gets raised in the response.json() method, and is backwards compatible as it inherits from previously thrown exceptions. Can be caught from requests.exceptions.RequestException as well. (#5856)
- Improved error text for misnamed InvalidSchema and MissingSchema exceptions. This is a temporary fix until exceptions can be renamed (Schema->Scheme). (#6017)
- Improved proxy parsing for proxy URLs missing a scheme. This will address recent changes to urlparse in Python 3.9+. (#5917)
#### Bugfixes:
- Fixed defect in extract_zipped_paths which could result in an infinite loop for some paths. (#5851)
- Fixed handling for AttributeError when calculating length of files obtained by Tarfile.extractfile(). (#5239)
- Fixed urllib3 exception leak, wrapping urllib3.exceptions.InvalidHeader with requests.exceptions.InvalidHeader. (#5914)
- Fixed bug where two Host headers were sent for chunked requests. (#5391)
- Fixed regression in Requests 2.26.0 where Proxy-Authorization was incorrectly stripped from all requests sent with Session.send. (#5924)
- Fixed performance regression in 2.26.0 for hosts with a large number of proxies available in the environment. (#5924)
- Fixed idna exception leak, wrapping UnicodeError with requests.exceptions.InvalidURL for URLs with a leading dot (.) in the domain. (#5414)
#### Deprecations:
- Requests support for Python 2.7 and 3.6 will be ending in 2022. While we don't have exact dates, Requests 2.27.x is likely to be the last release series providing support.

### 2.26.0 (2021-07-13)
#### Improvements:
- Requests now supports Brotli compression, if either the brotli or brotlicffi package is installed. (#5783)
- Session.send now correctly resolves proxy configurations from both the Session and Request. Behavior now matches Session.request. (#5681)
#### Bugfixes:
- Fixed a race condition in zip extraction when using Requests in parallel from zip archive. (#5707)
#### Dependencies:
- Instead of chardet, use the MIT-licensed charset_normalizer for Python3 to remove license ambiguity for projects bundling requests. If chardet is already installed on your machine it will be used instead of charset_normalizer to keep backwards compatibility. (#5797)
- You can also install chardet while installing requests by specifying [use_chardet_on_py3] extra as follows:
- pip install "requests[use_chardet_on_py3]"
- Python2 still depends upon the chardet module.
- Requests now supports idna 3.x on Python 3. idna 2.x will continue to be used on Python 2 installations. (#5711)
#### Deprecations:
- The requests[security] extra has been converted to a no-op install. PyOpenSSL is no longer the recommended secure option for Requests. (#5867)
- Requests has officially dropped support for Python 3.5. (#5867)

### 2.25.1 (2020-12-16)
#### Bugfixes:
- Requests now treats application/json as utf8 by default. Resolving inconsistencies between r.text and r.json output. (#5673)
#### Dependencies:
- Requests now supports chardet v4.x.

### 2.25.0 (2020-11-11)
#### Improvements:
- Added support for NETRC environment variable. (#5643)
#### Dependencies:
- Requests now supports urllib3 v1.26.
#### Deprecations:
- Requests v2.25.x will be the last release series with support for Python 3.5.
- The requests[security] extra is officially deprecated and will be removed in Requests v2.26.0.

### 2.24.0 (2020-06-17)
#### Improvements:
- pyOpenSSL TLS implementation is now only used if Python either doesn't have an ssl module or doesn't support SNI. Previously pyOpenSSL was unconditionally used if available. This applies even if pyOpenSSL is installed via the requests[security] extra (#5443)
- Redirect resolution should now only occur when allow_redirects is True. (#5492)
- No longer perform unnecessary Content-Length calculation for requests that won't use it. (#5496)

### 2.23.0 (2020-02-19)
#### Improvements:
- Remove defunct reference to prefetch in Session __attrs__ (#5110)
#### Bugfixes:
- Requests no longer outputs password in basic auth usage warning. (#5099)
#### Dependencies:
- Pinning for chardet and idna now uses major version instead of minor. This hopefully reduces the need for releases every time a dependency is updated.
</details>
<details>
  <summary>msgpack from 1.0.2 to 1.0.3</summary>

1.0.3
=====
Release Date: 2021-11-24 JST

* Fix Docstring (#459)
* Fix error formatting (#463)
* Improve error message about strict_map_key (#485)

1.0.2
=====
* Fix year 2038 problem regression in 1.0.1. (#451)

1.0.1
=====
* Add Python 3.9 and linux/arm64 wheels. (#439)
* Fixed Unpacker.tell() after read_bytes() (#426)
* Fixed unpacking datetime before epoch on Windows (#433)
* Fixed fallback Packer didn't check DateTime.tzinfo (#434)
</details>