### PR TITLE
Updated websocket library and fixed bugs due to reconnects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 msgpack==1.0.2
 requests>=2.22.0
-websocket-client==1.0.0
+websocket-client==1.4.2


### PR DESCRIPTION
This fixes #97 . I removed unnecessary threads that were being created around `run_forever`. `run_forever` already creates a thread so this is a waste of resources. I also discovered the constant reconnect issue was because the connection checker was continuing to run while in reconnect mode. This was because of a bad state check. We now kill the connection checker no matter what when `stop()` is called. I also updated the websocket-client library because it was very out of date. This resolved all my issues and seemed to introduce no additional problems in my testing.

This library seems like it might be dead but I hope you'll consider this PR. I'd hate to have to maintain a fork just to fix this bug :( 