### PR TITLE
Guess port if not defined and include GET parameters on connect

### DIFF
--- a/signalrcore/transport/websockets/websocket_client.py
+++ b/signalrcore/transport/websockets/websocket_client.py
@@ -118,8 +118,11 @@ class WebSocketClient(object):
 
         # Perform the WebSocket handshake
         key = base64.b64encode(os.urandom(16)).decode("utf-8")
+        relative_reference = parsed_url.path
+        if parsed_url.query:
+            relative_reference = f"{parsed_url.path}?{parsed_url.query}"
         request_headers = [
-            f"GET {parsed_url.path} HTTP/1.1",
+            f"GET {relative_reference} HTTP/1.1",
             f"Host: {parsed_url.hostname}",
             "Upgrade: websocket",
             "Connection: Upgrade",


### PR DESCRIPTION
I noticed 2 regressions compared to 0.9.5: 

1. commit: I didn't define the port in my URL - not a big issue, but websocket-client defaulted to 443 or 80 depending on scheme. I could also understand requiring the user to define the port, but in that case there should probably a ValueError raised if `port is None`.

2. commit: The service I connect to requires me to provide an API key as a GET parameter, and the `parsed_url.path` didn't include that.

I just coded this together in my first ever Github codespace, and didn't run lint / tests yet - feel free to disregard and just use this PR as an issue with example code :D